### PR TITLE
Intervalo de cálculos mAP cambiado

### DIFF
--- a/src/detector.c
+++ b/src/detector.c
@@ -283,8 +283,9 @@ void train_detector(char *datacfg, char *cfgfile, char *weightfile, int *gpus, i
 
         int calc_map_for_each = 4 * train_images_num / (net.batch * net.subdivisions);  // calculate mAP for each 4 Epochs
         calc_map_for_each = fmax(calc_map_for_each, 100);
-        int next_map_calc = iter_map + calc_map_for_each;
-        next_map_calc = fmax(next_map_calc, net.burn_in);
+        int next_map_calc=iter_map+100;
+        //int next_map_calc = iter_map + calc_map_for_each;
+        //next_map_calc = fmax(next_map_calc, net.burn_in);
         //next_map_calc = fmax(next_map_calc, 400);
         if (calc_map) {
             printf("\n (next mAP calculation at %d iterations) ", next_map_calc);


### PR DESCRIPTION
Ahora el cálculo de mAP se produce cada 100 iteraciones independientemente del burn in, los batchs o las subdivisions que haya.